### PR TITLE
Add workflow4metabolomics tools

### DIFF
--- a/monitor.sh
+++ b/monitor.sh
@@ -10,6 +10,7 @@ declare -a REPOSITORIES=(
     "https://github.com/TGAC/earlham-galaxytools"
     "https://github.com/AAFC-MBB/Galaxy"
     "https://github.com/phac-nml/galaxy_tools"
+    "https://github.com/workflow4metabolomics/tools-w4m"
 )
 
 : ${PLANEMO_TARGET:="planemo==0.42.1"}


### PR DESCRIPTION
Hi,
I have just gathered a couple of tools in a IUC/devteam like repository [tools-w4m](https://github.com/workflow4metabolomics/tools-w4m)

Until now, we used (I was again) to have one GitHub repository [per tool](https://github.com/workflow4metabolomics). But since your talk @jmchilton at GCC, I believe that merging our tools within one repo can be interesting to get all the cool stuff the community developed.

Before going further in the merging process, I need to convince my collegue :/
Those biocontainers should be a good start!