### PR TITLE
Random repo order

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,12 @@ env:
   - MULLED_NAMESPACE=jmchiltonorg
   - GITHUB_USER=dockerhub-toolshed
   - secure: VDDSnaojmTBGz0rKWibM6Kuz9YdhVKtwQZ6UqouU8DUiFjSqf8/JApPxfvxkEJO0H5y/8FnaQwcGVkLWchgBjU2dLZIDpQSix3lfmuffd/OLfWA7BtzuT5pYoz2KwiZcis29vDCqE2vyXBnd0FqsSdq/aIik1vhiVp/yJVpD3beAFyVHawcnqcSswW525NCeJPhKv+QF6UAwwGXF/xgrx9E5F59Q880Q1HLRStsuQHGrgVuc3fk0RiC7DeD7jVd1lBdNodTKEckj4HdbL9WAiNGJ2hVhUtsaqEvA9hd+0Cr7sIOOYygZVA9IPp8xHZdZYpOJ5ruC66Ba+d7+XfIjfNI1qBjP76lAAZK55yzxR7SUvQpLynpB5sodjwQrZGI4PEmsFFgHE227Q5ox+2dIcfHy02aNP3Qij+iTOmKwFhi6qeHKa5kC7GyN7CrQlM8MauF/zNwX3OOu9ayNs1Nzowj1Ys7N9wTPDkZbH7R7xNobW4eCHk9MXjGdPCbhj4RSsZ027Kr2MsKo9q71bnU/M1d9Q58Hyw8mRVgu2JFB4VbFJiFHaJgoIWW95pDyi0dvoZJSjzpdC/HlZw/dRHkhZK+EXaMxXouh8//4GaniUXW4bEhEADK3RsgCTat5FmH1CULJQ6OdN/3fmbRRclkSIJkqYfYHYIv4gRMPcH9nMm0=
+branches:
+  only:
+  - master
 script:
 - |
+  if [ "${TRAVIS_BRANCH}" == "master" ] && [ "${TRAVIS_PULL_REQUEST}" == false ]; then
        declare -r SSH_FILE="$(mktemp -u $HOME/.ssh/XXXXX)"
 
        # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -30,6 +34,7 @@ script:
               "Host github.com" \
               "  IdentityFile $SSH_FILE" \
               "  LogLevel ERROR" >> ~/.ssh/config
+  fi
 - git config --global user.email "$GITHUB_USER@galaxyproject.org"
 - git config --global user.name "$GITHUB_USER"
 - bash monitor.sh

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ tools will have containers published and available on quay.io.
 
 ## Adding Your Repository
 
-Feel free to open a pull request to add your repository to the list in monitor.sh to monitor
-your tools published to Github as well.
+Feel free to open a pull request to add your repository to the list in `repositories.list` to monitor
+your tools published tn GitHub as well.
 
 ## Implementation
 

--- a/monitor.sh
+++ b/monitor.sh
@@ -1,18 +1,5 @@
 #!/bin/bash
 
-declare -a REPOSITORIES=(
-    "https://github.com/galaxyproject/tools-iuc"
-    "https://github.com/galaxyproject/tools-devteam"
-    "https://github.com/galaxyproteomics/tools-galaxyp"
-    "https://github.com/bgruening/galaxytools"
-    "https://github.com/peterjc/pico_galaxy"
-    "https://github.com/genouest/tools-colibread"
-    "https://github.com/TGAC/earlham-galaxytools"
-    "https://github.com/AAFC-MBB/Galaxy"
-    "https://github.com/phac-nml/galaxy_tools"
-    "https://github.com/workflow4metabolomics/tools-w4m"
-)
-
 : ${PLANEMO_TARGET:="planemo==0.46"}
 : ${PLANEMO_OPTIONS:="--verbose"}
 
@@ -26,7 +13,7 @@ fi
 
 planemo $PLANEMO_OPTIONS conda_init
 
-for repository in "${REPOSITORIES[@]}"
+sort -R repositories.list | while read repository
 do
    repo_dir=`basename "$repository"`
    git clone "$repository" "$repo_dir"

--- a/repositories.list
+++ b/repositories.list
@@ -1,0 +1,10 @@
+https://github.com/galaxyproject/tools-iuc
+https://github.com/galaxyproject/tools-devteam
+https://github.com/galaxyproteomics/tools-galaxyp
+https://github.com/bgruening/galaxytools
+https://github.com/peterjc/pico_galaxy
+https://github.com/genouest/tools-colibread
+https://github.com/TGAC/earlham-galaxytools
+https://github.com/AAFC-MBB/Galaxy
+https://github.com/phac-nml/galaxy_tools
+https://github.com/workflow4metabolomics/tools-w4m


### PR DESCRIPTION
We have already a lot of repos to track and depending how much time we spend on each, we will sooner or later run into the travis timeout. This is not super problematic as we run these scripts every day, but currently we are processing the repos in a deterministic oder. Means if we spend too much time on one repo, we try again tomorrow and maybe we never end up with the last repo in our list. 

This PR changes this by randomly shuffle the repos, so we start every time with a new repo. I think this is enough for the time being. At some point we will speed up the calculations by simply looking only at the changes from the last 48d. 

Is this ok for the time being @jmchilton?