### PR TITLE
Update genouest repo

### DIFF
--- a/repositories01.list
+++ b/repositories01.list
@@ -1,4 +1,4 @@
-https://github.com/genouest/tools-colibread
+https://github.com/genouest/galaxy-tools
 https://github.com/TGAC/earlham-galaxytools
 https://github.com/AAFC-MBB/Galaxy
 https://github.com/phac-nml/galaxy_tools


### PR DESCRIPTION
As promised in https://github.com/genouest/galaxy-tools/issues/17 ;)
I removed the colibread repo as it was deleted, now all these tools are in IUC