### PR TITLE
Add galaxy itself to list of monitored repos

### DIFF
--- a/repositories01.list
+++ b/repositories01.list
@@ -1,3 +1,4 @@
+https://github.com/galaxyproject/galaxy
 https://github.com/genouest/galaxy-tools
 https://github.com/TGAC/earlham-galaxytools
 https://github.com/AAFC-MBB/Galaxy


### PR DESCRIPTION
Seems like a glaring omission, we have a couple of multi-dependency
tools and converters.