### PR TITLE
Update W4M repo - add xcms

### DIFF
--- a/repositories01.list
+++ b/repositories01.list
@@ -3,7 +3,7 @@ https://github.com/genouest/galaxy-tools
 https://github.com/TGAC/earlham-galaxytools
 https://github.com/AAFC-MBB/Galaxy
 https://github.com/phac-nml/galaxy_tools
-https://github.com/workflow4metabolomics/tools-w4m
+https://github.com/workflow4metabolomics/xcms
 https://github.com/galaxy-genome-annotation/galaxy-tools
 https://github.com/HegemanLab/w4mcorcov_galaxy_wrapper
 https://github.com/HegemanLab/w4mclassfilter_galaxy_wrapper


### PR DESCRIPTION
@bgruening 
I was right, I had already include a sort of W4M repo within Planemo monitor.
The repo I had at the moment, was a test of fusion of 3 differents W4M repository. I did that to show to the group, how it looks like to have all in one.
But I don't maintain it.

I still need to convince the group about merge all our repository. I have arguments, especially since I'm mainly the guy who browse all those git repo to update this or that. 
Meanwhile, if you don't mind, I propose to add some of them, one by one. Let me know if it takes too munch CI time. 