### PR TITLE
w4m - replace 2 repo by one

### DIFF
--- a/repositories01.list
+++ b/repositories01.list
@@ -3,8 +3,7 @@ https://github.com/genouest/galaxy-tools
 https://github.com/TGAC/earlham-galaxytools
 https://github.com/AAFC-MBB/Galaxy
 https://github.com/phac-nml/galaxy_tools
-https://github.com/workflow4metabolomics/xcms
-https://github.com/workflow4metabolomics/camera
+https://github.com/workflow4metabolomics/tools-metabolomics
 https://github.com/galaxy-genome-annotation/galaxy-tools
 https://github.com/HegemanLab/w4mcorcov_galaxy_wrapper
 https://github.com/HegemanLab/w4mclassfilter_galaxy_wrapper


### PR DESCRIPTION
We finally agree to merge our several repo in one: https://github.com/workflow4metabolomics/tools-metabolomics

The work is still in progress.

FYI, this repo is open and "could be" a central repo for any tools from the metabolomics world, if it's adopted.