### PR TITLE
Add support for restricting the search for tools to a subpath

### DIFF
--- a/monitor.sh
+++ b/monitor.sh
@@ -13,10 +13,10 @@ fi
 
 planemo conda_init
 
-sort -R $1 | while read repository
+sort -R $1 | while read repository subpath
 do
    repo_dir=$(basename "$repository")
    git clone --depth=1 "$repository" "$repo_dir"
-   planemo container_register --force_push --recursive "$repo_dir"
+   planemo container_register --force_push --recursive "$repo_dir$subpath"
    rm -rf "$repo_dir"
 done


### PR DESCRIPTION
repositories*.list can optionally have a path relative to the repo root follow the repo url separated by a space.
This path will restrict the search for tools to only that subpath. The path must begin with a `/`.