### PR TITLE
Update repositories04.list with larch-tools

### DIFF
--- a/repositories04.list
+++ b/repositories04.list
@@ -12,3 +12,4 @@ https://github.com/phac-nml/snvphyl-galaxy.git
 https://github.com/muon-spectroscopy-computational-project/muon-galaxy-tools
 https://github.com/lldelisle/tools-lldelisle
 https://github.com/peterjc/galaxy_blast
+https://github.com/MaterialsGalaxy/larch-tools


### PR DESCRIPTION
Adding tools for X-ray (materials science) use cases.

Wasn't aware this was how we were handling the containers for the [muon tools](https://github.com/muon-spectroscopy-computational-project/muon-galaxy-tools) at first, so spent some time trying to build the containers manually via the admin UI on our Galaxy instance. I think that may have already caused some images to have been pushed to quay. If that's a problem or we need to do anything else to set this up for a new tool repo, please let me know.