### PR TITLE
add pasteur.fr galaxy-tools repo

### DIFF
--- a/repositories04.list
+++ b/repositories04.list
@@ -14,3 +14,4 @@ https://github.com/lldelisle/tools-lldelisle
 https://github.com/peterjc/galaxy_blast
 https://github.com/MaterialsGalaxy/larch-tools
 https://github.com/geraldinepascal/FROGS-wrappers
+https://gitlab.pasteur.fr/galaxy-team/galaxy-tools


### PR DESCRIPTION
I would like to use defense-finder containerized. Repo seems to contain copies of (old versions) of tools that are now in IUC or elsewhere. 

Or would it be better to move tools to IUC?