### PR TITLE
add computational-metabolomics repos

### DIFF
--- a/repositories01.list
+++ b/repositories01.list
@@ -4,6 +4,9 @@ https://github.com/TGAC/earlham-galaxytools
 https://github.com/AAFC-MBB/Galaxy
 https://github.com/phac-nml/galaxy_tools
 https://github.com/workflow4metabolomics/tools-metabolomics
+https://github.com/computational-metabolomics/cfm-galaxy
+https://github.com/computational-metabolomics/metfrag-galaxy
+https://github.com/computational-metabolomics/mspurity-galaxy/
 https://github.com/galaxy-genome-annotation/galaxy-tools
 https://github.com/HegemanLab/w4mcorcov_galaxy_wrapper
 https://github.com/HegemanLab/w4mclassfilter_galaxy_wrapper


### PR DESCRIPTION
Hopefully these tools will be in a common tool repo in the future (https://github.com/computational-metabolomics/cfm-galaxy/issues/9). So long we need to list them separately here.