### PR TITLE
Revert fixes

### DIFF
--- a/monitor.sh
+++ b/monitor.sh
@@ -2,20 +2,17 @@
 
 planemo conda_init
 
-exit_code="0"
-sort -R "$1" | while read repository
+sort -R $1 | while read repository
 do
     repo_dir=$(basename "$repository")
     git clone --depth=1 "$repository" "$repo_dir"
     cd "$repo_dir"
     planemo ci_find_repos  --exclude packages --exclude deprecated --exclude_from .tt_skip --output repository_list.txt
-    while read tool_dir
+    cat repository_list.txt | while read tool_dir
     do
         planemo container_register --force_push --recursive "$tool_dir"
-        exit_code=$(( "$exit_code" | "$?" ))
-    done < repository_list.txt
+    done
     cd -
     rm -rf "$repo_dir"
 done
 
-exit $exit_code

--- a/monitor.sh
+++ b/monitor.sh
@@ -4,15 +4,9 @@ planemo conda_init
 
 sort -R $1 | while read repository
 do
-    repo_dir=$(basename "$repository")
-    git clone --depth=1 "$repository" "$repo_dir"
-    cd "$repo_dir"
-    planemo ci_find_repos  --exclude packages --exclude deprecated --exclude_from .tt_skip --output repository_list.txt
-    cat repository_list.txt | while read tool_dir
-    do
-        planemo container_register --force_push --recursive "$tool_dir"
-    done
-    cd -
-    rm -rf "$repo_dir"
+   repo_dir=$(basename "$repository")
+   git clone --depth=1 "$repository" "$repo_dir"
+   planemo container_register --force_push --recursive "$repo_dir"
+   rm -rf "$repo_dir"
 done
 


### PR DESCRIPTION
reverts https://github.com/galaxyproject/planemo-monitor/pull/42

problem is that each `planemo container_register` creates a fork which results in 403s from github. 

no idea why we create a new fork for each run. 